### PR TITLE
docs(readme): update project title and add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# pool-apa-team-rankings
+# APALens
+
+A Flask web application for viewing APA (American Poolplayers Association) team and player statistics.
+
+![Pool APA](https://greaterseattle.apaleagues.com/Uploads/greaterseattle/YO.jpg)
+
+## 🚧 Work in Progress
+
+## Quick Start
+
+```bash
+# Install and run
+pip install -e .
+export APA_REFRESH_TOKEN="your-apa-refresh-token"
+python -m flask run
+
+# Or with Docker
+docker build -t apalens .
+docker run -p 5000:5000 apalens
+```
+
+## Contributing
+Contributions welcome! Please ensure all tests pass before submitting a PR.
+
+---
+
+**Note**: This application is not affiliated with the American Poolplayers Association (APA). It's an independent tool for viewing publicly available APA statistics.


### PR DESCRIPTION
What:  
Update `README.md` to reflect the actual project name and purpose, and add quick start instructions for local and Docker usage.

Key Changes:  
- Renamed project title from `pool-apa-team-rankings` to `APALens`  
- Added a brief description of the app  
- Included an APA-related image  
- Added quick start instructions for pip and Docker usage  
- Added a contributing note and disclaimer about APA affiliation

Testing:  
- No code changes; documentation only  
- Previewed README in markdown viewer to ensure formatting is correct

